### PR TITLE
Allow for HTTP methods other than get

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -141,7 +141,7 @@ module.exports = class TwitchHelix extends EventEmitter {
                 retryStrategy: this.shouldRetryRequest
             })
         }
-        request.get(query, queryOptions, (error, response, body) => {
+        request(query, queryOptions, (error, response, body) => {
             if (response && response.request) {
                 this.log("info", `${response.request.method} ${response.request.href}`)
             }


### PR DESCRIPTION
twitch-helix is a fine library for working with both the Helix and Kraken libraries together, but has one weakness... you can only do GET requests.

No longer.  This pull request allows for all HTTP methods so that you can use all the Twitch API endpoints.  This is achieved by adding a `method` key to the requestOptions object.  It is optional, and defaults to `"GET"` as to provide existing 

Example code that utilizes this:

```
api.sendApiRequest(`channels/${id}`, {requestOptions: {method: "PUT", json: {channel: {status: "This is the title of my stream!"}}, api: "kraken"});
```