### PR TITLE
Fixes the case of response being undefined during shouldRetryRequest

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "babel-preset-minify": "^0.2.0",
         "babel-preset-stage-2": "^6.24.1",
         "dotenv": "^4.0.0",
-        "gulp": "^3.9.1",
+        "gulp": "^4.0.2",
         "gulp-babel": "^7.0.0",
         "gulp-clean": "^0.3.2",
         "jest": "^22.0.4",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -69,7 +69,7 @@ module.exports = class TwitchHelix extends EventEmitter {
     }
 
     shouldRetryRequest = (error, response, body) => {
-        if (response.headers) {
+        if (response && response.headers) {
             this.rateLimit = {
                 limit: response.headers["ratelimit-limit"],
                 remaining: response.headers["ratelimit-remaining"],


### PR DESCRIPTION
It is a legitimate case that the response may not be set during a call
to shouldRetryRequest, so we need to handle this gracefully. All
downstream code already handles this.